### PR TITLE
Fix Sidechain.sol

### DIFF
--- a/gringotts/contracts/Sidechain.sol
+++ b/gringotts/contracts/Sidechain.sol
@@ -73,9 +73,6 @@ contract Sidechain {
     }
 
     function () payable {
-        if(assetAddresses[msg.sender] == false) {
-            revert();
-        }
         /*
         called delegateToLib to 'proposeDeposit(bytes32[])'
         gas used : 127075


### PR DESCRIPTION
Why
* Contract will revert when send ether to sidechain, which means we cannot deposit ether.

Change
* Remove assetAddresses checkout function.