### PR TITLE
Change interface to contract

### DIFF
--- a/gringotts/contracts/SidechainLib.sol
+++ b/gringotts/contracts/SidechainLib.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.23;
 
-interface Token {
+contract Token {
     function transfer(address _to, uint256 _value) public returns (bool success);
 }
 


### PR DESCRIPTION
Why
* Cannot withdraw token.

Change
* `interface` to `contract`