### PR TITLE
Fix standalone deployment bug

### DIFF
--- a/gringotts/testDeployBooster.js
+++ b/gringotts/testDeployBooster.js
@@ -1,30 +1,40 @@
 /*
 node testDeployBooster.js
---boosterOwner 0x111 // booster owner address
---assetAddress 0x222 // asset contract address
---assetAddress 0x333 // if assetAddress more than one
---maxWithdraw 10 // maximum value of instant withdraw, default 10
---managerAddress 0x444 // infinitechainManager contract address
+--managerAddress 0x111 // infinitechainManager contract address.
+--boosterOwner 0x222 // booster owner address, default infinitechainManager owner address.
+--assetAddress 0x333 // support token contract address, default empty array.
+--assetAddress 0x444 // if support token more than one.
+--maxWithdraw 10 // maximum value of instant withdraw, default 10 ether.
+--network devnet // network setting, default devnet. opt: 1. devnet 2. testnet 3. mainnet
 */
-var argv = require('minimist')(process.argv.slice(2), { string: ['managerAddress', 'boosterOwner', 'assetAddress', 'maxWithdraw'] });
+var argv = require('minimist')(process.argv.slice(2), { string: ['managerAddress', 'boosterOwner', 'assetAddress', 'maxWithdraw', 'network'] });
+let InfinitechainManager = require('./build/contracts/InfinitechainManager.json');
+let EthUtils = require('ethereumjs-util');
 let Web3 = require('web3');
 let env = require('./env');
-let InfinitechainManager = require('./build/contracts/InfinitechainManager.json');
-let web3Url = 'http://' + env.web3Host + ':' + env.web3Port;
-let web3 = new Web3(new Web3.providers.HttpProvider(web3Url));
+
+let network = env.devnet;
+if (argv.network == 'testnet') {
+    network = env.testnet;
+} else if (argv.network == 'mainnet') {
+    network = env.mainnet;
+}
+let web3 = new Web3(new Web3.providers.HttpProvider(network.web3Url));
+let publickey = '0x' + EthUtils.privateToPublic('0x' + network.privateKey).toString('hex');
+let account = '0x' + EthUtils.pubToAddress(publickey).toString('hex');
+
 let im = web3.eth.contract(InfinitechainManager.abi).at(argv.managerAddress);
 let boosterNumber = im.boosterNumber().toNumber();
+let boosterOwner = argv.boosterOwner? argv.boosterOwner : im.owner();
 let assetList = [];
 if (typeof argv.assetAddress == 'string') {
     assetList.push(argv.assetAddress);
 } else if (typeof argv.assetAddress == 'object') {
     assetList = argv.assetAddress;
 }
-let maxWithdraw = web3.toWei(10);
-if (argv.maxWithdraw) {
-    maxWithdraw = web3.toWei(parseInt(argv.maxWithdraw));
-}
-im.deployBooster(argv.boosterOwner, assetList, maxWithdraw, { from: env.account, gas: 1500000 });
+let maxWithdraw = argv.maxWithdraw? web3.toWei(parseInt(argv.maxWithdraw)) : web3.toWei(10);
+
+im.deployBooster(boosterOwner, assetList, maxWithdraw, { from: account, gas: 1500000 });
 let second = 0;
 let timeout = 120;
 let getBoosterAddress = setInterval(() => {


### PR DESCRIPTION
How to use:
infinitecgain_manager contrasct address: 0x123

Booster owner use manager owner, maxWithdraw use default value and booster not support any token
```
node testDeployBooster.js --managerAddress 0x123
```
Booster support one kinds of token
```
node testDeployBooster.js --managerAddress 0x123 --assetAddress 0x777
```
Booster support two kinds of token, etc.
```
node testDeployBooster.js --managerAddress 0x123 --assetAddress 0x777 --assetAddress 0x888
```
Change booster owner and maxWithdraw value
```
node testDeployBooster.js --managerAddress 0x123 --boosterOwner 0x456 --maxWithdraw 15
```